### PR TITLE
[.github] Add double quote in check_commit workflow

### DIFF
--- a/.github/workflows/check-commit.yml
+++ b/.github/workflows/check-commit.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Get commit message
         if: github.event_name == 'push'
         run: |
-          echo ${{ github.event.head_commit.message }} > commit_msg.txt
+          echo "${{ github.event.head_commit.message }}" > commit_msg.txt
       - name: Get commit message
         if: github.event_name == 'pull_request'
         run: |


### PR DESCRIPTION
This commit adds double quote in check_commit workflow to fix push event error.