### PR TITLE
[.github] Use main branch as default branch

### DIFF
--- a/.github/workflows/check-commit.yml
+++ b/.github/workflows/check-commit.yml
@@ -2,9 +2,9 @@ name: Check Commit
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   check-commit:


### PR DESCRIPTION
This commit uses main branch as default branch.